### PR TITLE
Refactor Pool implemenation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,11 @@ run:
 	@test -z "$(EXAMPLE)" && echo "Usage: make [$(EXAMPLES)] run" || go run ./example/$(EXAMPLE)
 
 test:
+ifdef CI
+	@ginkgo -r --randomizeAllSpecs --randomizeSuites --failOnPending --cover --trace --race --progress
+else
 	@ginkgo --failFast ./...
+endif
 
 test-watch:
 	@ginkgo watch --debug -cover -r ./...

--- a/README.md
+++ b/README.md
@@ -34,14 +34,15 @@ func main() {
     producer := prdcsm.NewChannelProducer(50)
 
     i := 0
-    pool := prdcsm.Pool{
+    pool := prdcsm.NewPool(prdcsm.PoolConfig{
+        Workers: 4,
         Consumer: func(data interface{}) {
             fmt.Println(data, " ")
             i++
             time.Sleep(time.Millisecond * 110)  // Simulate a "heavy" consumer proccess.
         },
         Producer: producer,
-    }
+    })
 
 
     go func() {
@@ -51,7 +52,7 @@ func main() {
         }
     }()
 
-    pool.Run(4) // Starts running the workers
+    pool.Start() // Starts running the workers
 }
 ```
 

--- a/example/basic/main.go
+++ b/example/basic/main.go
@@ -18,14 +18,15 @@ func main() {
 	producer := prdcsm.NewChannelProducer(50)
 
 	i := 0
-	pool := prdcsm.Pool{
+	pool := prdcsm.NewPool(prdcsm.PoolConfig{
+		Workers: 4,
 		Consumer: func(data interface{}) {
 			fmt.Println(data, " ")
 			i++
 			time.Sleep(time.Millisecond * 110)
 		},
 		Producer: producer,
-	}
+	})
 
 	go func() {
 		for {
@@ -34,5 +35,5 @@ func main() {
 		}
 	}()
 
-	pool.Run(4)
+	pool.Start()
 }

--- a/example/eof/main.go
+++ b/example/eof/main.go
@@ -20,14 +20,15 @@ func main() {
 	}
 
 	i := 0
-	pool := prdcsm.Pool{
+	pool := prdcsm.NewPool(prdcsm.PoolConfig{
+		Workers: 4,
 		Consumer: func(data interface{}) {
 			fmt.Println(data, " ")
 			i++
 			time.Sleep(time.Millisecond * 110)
 		},
 		Producer: producer,
-	}
+	})
 
 	go func() {
 		s := time.Now()
@@ -41,5 +42,5 @@ func main() {
 		}
 	}()
 
-	pool.Run(4)
+	pool.Start()
 }

--- a/example/stoppable/main.go
+++ b/example/stoppable/main.go
@@ -20,14 +20,15 @@ func main() {
 	}
 
 	i := 0
-	pool := prdcsm.Pool{
+	pool := prdcsm.NewPool(prdcsm.PoolConfig{
+		Workers: 4,
 		Consumer: func(data interface{}) {
 			fmt.Println(data, " ")
 			i++
 			time.Sleep(time.Millisecond * 110)
 		},
 		Producer: producer,
-	}
+	})
 
 	producerRunning := true
 	go func() {
@@ -37,9 +38,11 @@ func main() {
 		}
 	}()
 
-	go pool.Run(4)
+	go func() {
+		time.Sleep(time.Second * 1)
+		producerRunning = false
+		pool.Stop()
+	}()
 
-	time.Sleep(time.Second * 1)
-	producerRunning = false
-	pool.Stop()
+	pool.Start()
 }

--- a/example/stoppable/main.go
+++ b/example/stoppable/main.go
@@ -37,11 +37,9 @@ func main() {
 		}
 	}()
 
-	go func() {
-		time.Sleep(time.Second * 1)
-		producerRunning = false
-		pool.Stop()
-	}()
+	go pool.Run(4)
 
-	pool.Run(4)
+	time.Sleep(time.Second * 1)
+	producerRunning = false
+	pool.Stop()
 }

--- a/pool.go
+++ b/pool.go
@@ -70,14 +70,13 @@ func (pool *Pool) Run(count int) {
 
 			// Check the end of the
 			if data == EOF {
-				pool.Producer.Stop()
-				break
+				return
 			}
 
 			// Grabs a worker from the channel pool
 			worker, more := <-pool.consumerPool
 			if !more { // No more workers to process.
-				break
+				return
 			}
 			pool.waitGroupWorkers.Add(1)
 			go worker(data)

--- a/pool.go
+++ b/pool.go
@@ -106,6 +106,8 @@ func (pool *Pool) Wait() {
 // BE AWARE: The running workers will not be stopped. The stop will finalize the
 // pool and WAIT the workers stop by themselves.
 func (pool *Pool) Stop() {
-	pool.cancel()
+	if pool.ctx != nil && pool.ctx.Err() == nil {
+		pool.cancel()
+	}
 	pool.Wait()
 }

--- a/pool_test.go
+++ b/pool_test.go
@@ -54,6 +54,33 @@ var _ = Describe("Pool", func() {
 		Expect(called.count()).To(Equal(100))
 		close(done)
 	})
+	It("should ignore nils", func(done Done) {
+		var called safecounter
+		producer := NewChannelProducer(50)
+		pool := Pool{
+			Producer: producer,
+			Consumer: func(data interface{}) {
+				called.inc(data.(int))
+			},
+		}
+
+		go pool.Run(4)
+
+		producer.Ch <- 10
+		producer.Ch <- nil
+		producer.Ch <- 20
+		producer.Ch <- nil
+		producer.Ch <- 30
+		producer.Ch <- nil
+		producer.Ch <- 40
+		producer.Ch <- nil
+
+		time.Sleep(50 * time.Millisecond)
+		pool.Stop()
+
+		Expect(called.count()).To(Equal(100))
+		close(done)
+	})
 
 	It("should stop on EOF", func(done Done) {
 		var called safecounter

--- a/producer_channel.go
+++ b/producer_channel.go
@@ -15,7 +15,12 @@ func NewChannelProducer(cap int) *ChannelProducer {
 
 // Produce gets the next element of the channel.
 func (producer *ChannelProducer) Produce() interface{} {
-	return <-producer.Ch
+	select {
+	case got := <-producer.Ch:
+		return got
+	default:
+		return nil
+	}
 }
 
 // Stop stops the producer closing the channel.


### PR DESCRIPTION
Main points:

* Control cancellation using Contexts
* Pool struct is private, must use the `NewPool` constructor
* Add ability to restart the Pool
* ChannelProducer's Produce function is not blocking anymore